### PR TITLE
Home page cards and configurable listen port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,13 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "app"
+            "program": "app",
+            "args": [
+                "-creds",
+                "../creds.json",
+                "-port",
+                "8080"
+            ]
         }
     ]
 }

--- a/app/main.go
+++ b/app/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -19,6 +20,7 @@ import (
 
 var (
 	creds = flag.String("creds", "../creds.json", "Google credential file.")
+	port  = flag.Int("port", 80, "Port to listen on.")
 )
 
 func mustGetCreds() []byte {
@@ -68,5 +70,9 @@ func main() {
 	handler.Register(r)
 
 	http.Handle("/", r)
-	http.ListenAndServe(":80", nil)
+	addr := strconv.Itoa(*port)
+	slog.Info("listening", "addr", "http://localhost:"+addr)
+	if err := http.ListenAndServe(":"+addr, nil); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/templates/list.go
+++ b/pkg/templates/list.go
@@ -12,15 +12,33 @@ var List = template.Must(template.New("List").Funcs(template.FuncMap{}).Parse(`
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>all Medicines</title>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css" integrity="sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls" crossorigin="anonymous">
+	<style>
+		.medicine-cards { padding: 0 0 1rem; }
+		.medicine-card {
+			display: block;
+			padding: 1.25rem 1.5rem;
+			margin-bottom: 0.75rem;
+			background: #f0f0f0;
+			border: 1px solid #ccc;
+			border-radius: 8px;
+			text-decoration: none;
+			color: #333;
+			font-size: 1.1rem;
+			transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+		}
+		.medicine-card:hover {
+			background: #e0e0e0;
+			border-color: #999;
+			box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+		}
+	</style>
 </head>
 <body>
 	<h1>All Medicines</h1>
-	<div class="pure-g">
-		<ul>
+	<div class="medicine-cards">
 		{{ range .Medicines }}
-			<li><a href="./{{.}}">{{.}}</a></li>
+		<a class="medicine-card" href="./{{.}}">{{.}}</a>
 		{{ end }}
-		</ul>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
- List medicines as full-width clickable cards instead of a plain list
- Add -port flag (default 80) to configure listen address
- Update launch.json to run with -port 8080 for local dev